### PR TITLE
fix: replace 8 bare excepts with except Exception

### DIFF
--- a/.github/scripts/build_docs.py
+++ b/.github/scripts/build_docs.py
@@ -448,7 +448,7 @@ def generate_sitemap():
         try:
             mtime = os.path.getmtime(filepath)
             return datetime.fromtimestamp(mtime).strftime('%Y-%m-%d')
-        except:
+        except Exception:
             return datetime.now().strftime('%Y-%m-%d')
     
     urls = []

--- a/micro-espectre/src/main.py
+++ b/micro-espectre/src/main.py
@@ -58,7 +58,7 @@ def cleanup_wifi(wlan):
     # Disable CSI first (may fail if not enabled, that's ok)
     try:
         wlan.csi_disable()
-    except:
+    except Exception:
         pass
     
     # Disconnect if connected

--- a/micro-espectre/src/mqtt/commands.py
+++ b/micro-espectre/src/mqtt/commands.py
@@ -133,7 +133,7 @@ class MQTTCommands:
                 channel_primary = self.wlan.config('channel')
                 # MicroPython doesn't expose secondary channel directly
                 channel_secondary = 0
-            except:
+            except Exception:
                 pass
             
             # WiFi protocol - decode bitmask
@@ -152,13 +152,13 @@ class MQTTCommands:
                 if proto_val & network.MODE_LR:
                     modes.append('LR')
                 protocol = '802.11' + '/'.join(modes) if modes else 'unknown'
-            except:
+            except Exception:
                 pass
             
             # CSI enabled (indicates promiscuous-like mode for CSI capture)
             try:
                 csi_enabled = hasattr(self.wlan, 'csi_available')
-            except:
+            except Exception:
                 pass
         
         # Get traffic generator rate (current runtime value)

--- a/micro-espectre/tests/test_nbvi_calibrator.py
+++ b/micro-espectre/tests/test_nbvi_calibrator.py
@@ -38,13 +38,13 @@ def cleanup_buffer_file():
     if os.path.exists(test_file):
         try:
             os.remove(test_file)
-        except:
+        except Exception:
             pass
     yield
     if os.path.exists(test_file):
         try:
             os.remove(test_file)
-        except:
+        except Exception:
             pass
 
 

--- a/micro-espectre/tools/csi_utils.py
+++ b/micro-espectre/tools/csi_utils.py
@@ -854,7 +854,7 @@ def get_dataset_stats() -> Dict[str, Any]:
                 try:
                     sample = np.load(samples[0])
                     avg_packets = sample['num_packets']
-                except:
+                except Exception:
                     avg_packets = 0
                 
                 stats['labels'][label] = {


### PR DESCRIPTION
> **Note**: Targeting the `develop` branch as per contribution guidelines.

## Description

Replace 8 bare `except:` clauses with `except Exception:` across 5 files.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/scripts/build_docs.py`: 1 bare except in `get_lastmod()`
- `micro-espectre/src/main.py`: 1 bare except in CSI cleanup
- `micro-espectre/src/mqtt/commands.py`: 3 bare excepts in WiFi config queries
- `micro-espectre/tests/test_nbvi_calibrator.py`: 2 bare excepts in test fixture cleanup
- `micro-espectre/tools/csi_utils.py`: 1 bare except in packet counting

## Why

Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which can mask real errors and prevent clean process termination. `except Exception:` preserves the intended error-suppression behavior while allowing system-level exceptions to propagate normally.

## Testing

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] My changes generate no new warnings