### PR TITLE
fix: update game.js serial parser to match wifi log format

### DIFF
--- a/docs/game/README.md
+++ b/docs/game/README.md
@@ -146,10 +146,10 @@ Sent once when `START` command is received. Used to display device configuration
 Sent at ~100 Hz (every CSI packet) while streaming is active. Uses ESPHome log format for clean line separation.
 
 ```
-[I][stream:NNN][espectre]: <movement>,<threshold>
+[I][espectre:NNN][wifi]: [---------------|----|] 0% | mvmt:<movement> thr:<threshold> | IDLE | NNN pkt/s | ch:N rssi:-NN
 ```
 
-Example: `[I][stream:075][espectre]: 0.73,1.50`
+Example: `[I][espectre:413][wifi]: [---------------|----] 0% | mvmt:0.7300 thr:1.5000 | MOTION | 107 pkt/s | ch:7 rssi:-47`
 
 ### Data Fields
 

--- a/docs/game/game.js
+++ b/docs/game/game.js
@@ -5,7 +5,8 @@
  * Stay still. Move fast. React to survive.
  * 
  * Communication: USB Serial (all ESP32 variants)
- * Protocol: "G<movement>,<threshold>\n" from ESP32
+ * Protocol: ESP32 → Browser: ESPHome wifi log line containing mvmt:<float> thr:<float>
+ *           Browser → ESP32: "START\n" / "STOP\n" / "T:X.XX\n"
  *           "START\n" / "STOP\n" / "T:X.XX\n" from browser
  * 
  * Author: Francesco Pace <francesco.pace@gmail.com>
@@ -556,10 +557,10 @@ class ESPectreGame {
             return;
         }
         
-        // Look for stream tag with data
-        // Format: [I][stream:NNN][espectre]: <movement>,<threshold>
-        // Example: [I][stream:075][espectre]: 0.08,1.00
-        const match = cleanLine.match(/\[stream:\d+\]\[.*?\]: ([\d.]+),([\d.]+)/);
+        // Look for wifi stream lines with mvmt/thr key-value pairs
+        // Format: [I][espectre:NNN][wifi]: ... mvmt:<movement> thr:<threshold> ...
+        // Example: [I][espectre:413][wifi]: [---------------|----] 0% | mvmt:0.0000 thr:5.0000 | IDLE | 109 pkt/s | ch:7 rssi:-57
+        const match = cleanLine.match(/\[I\]\[espectre:\d+\]\[wifi\]:.*mvmt:([\d.]+)\s+thr:([\d.]+)/);
         if (!match) {
             console.log(line);
             return;


### PR DESCRIPTION
The regex expected the old stream tag format with comma-separated values. The actual ESPHome wifi component emits key=value pairs inline in a progress-bar log line. Update the pattern to match [I][espectre:NNN][wifi]: as a validity guard, then scan for mvmt: and thr: anywhere in the line.

> **Note**: Please target the `develop` branch. PRs to `main` will not be accepted.

## Description

Fix the serial data parser in the browser game (`docs/game/game.js`) to match the actual WiFi log format emitted by the ESPHome component. The old regex matched a `[stream:NNN][espectre]: <float>,<float>` format that no longer exists, causing all device data to be silently dropped.

The log line is produced by `log_progress_bar()` in `components/espectre/sensor_publisher.cpp` (lines 75–79):

\```cpp
log_progress_bar(tag, progress, 20, 15,
                 "%d%% | mvmt:%.4f thr:%.4f | %s | %u pkt/s | ch:%d rssi:%d",
                 percent, motion_metric, threshold,
                 is_motion ? "MOTION" : "IDLE",
                 rate_pps, channel, rssi);
\```

This renders as:
\```
[I][espectre:413][wifi]: [---------------|----] 0% | mvmt:0.0000 thr:5.0000 | IDLE | 107 pkt/s | ch:7 rssi:-47
\```

The `[progress bar] 0% |` prefix between `]:` and `mvmt:` caused the old regex to never match.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Test update

## Related Issues

- NA

## Changes Made

- Updated regex in `docs/game/game.js` to match `[I][espectre:NNN][wifi]:` prefix and extract `mvmt:`/`thr:` key-value pairs from the full log line
- Updated format description and example in `docs/game/README.md` (lines 149, 152)
- Updated file header protocol comment in `docs/game/game.js` (line 8)

## Testing

Test environment:
- ESPHome 2026.1.5
- Chip: ESP32-C6, Cores=1, Revision=0 — CPU 160 MHz
- Framework: ESP-IDF 5.5.2 — Free Heap: 217976 bytes

- [x] I have tested these changes locally
- [ ] I have added tests that prove my fix/feature works
- [x] All existing tests pass

## Checklist

- [x] My code follows the project's code style
- [x] I have updated the documentation accordingly
- [ ] I have added an entry to CHANGELOG.md (if applicable)
- [x] My changes generate no new warnings

