### PR TITLE
feat: phase turbulence and SA-WiSense ratio turbulence signals

### DIFF
--- a/components/espectre/base_detector.cpp
+++ b/components/espectre/base_detector.cpp
@@ -66,6 +66,8 @@ BaseDetector::~BaseDetector() {
 BaseDetector::BaseDetector(BaseDetector&& other) noexcept
     : turbulence_buffer_(other.turbulence_buffer_)
     , num_amplitudes_(other.num_amplitudes_)
+    , last_phase_turbulence_(other.last_phase_turbulence_)
+    , last_ratio_turbulence_(other.last_ratio_turbulence_)
     , buffer_index_(other.buffer_index_)
     , buffer_count_(other.buffer_count_)
     , window_size_(other.window_size_)
@@ -91,6 +93,8 @@ BaseDetector& BaseDetector::operator=(BaseDetector&& other) noexcept {
         // Transfer all state
         turbulence_buffer_ = other.turbulence_buffer_;
         num_amplitudes_ = other.num_amplitudes_;
+        last_phase_turbulence_ = other.last_phase_turbulence_;
+        last_ratio_turbulence_ = other.last_ratio_turbulence_;
         buffer_index_ = other.buffer_index_;
         buffer_count_ = other.buffer_count_;
         window_size_ = other.window_size_;
@@ -127,19 +131,52 @@ void BaseDetector::process_packet(const int8_t* csi_data, size_t csi_len,
     int total_subcarriers = static_cast<int>(csi_len / 2);
     num_amplitudes_ = 0;
     
+    float phase_diffs[HT20_SELECTED_BAND_SIZE];
+    uint8_t num_phase_diffs = 0;
+    float prev_phase = 0.0f;
+    bool has_prev_phase = false;
+
     if (selected_subcarriers && num_subcarriers > 0) {
         for (int i = 0; i < num_subcarriers && num_amplitudes_ < HT20_SELECTED_BAND_SIZE; i++) {
             int sc_idx = selected_subcarriers[i];
             if (sc_idx >= total_subcarriers) continue;
-            
+
             // Espressif CSI format: [Imaginary, Real, ...] per subcarrier
             float Q = static_cast<float>(csi_data[sc_idx * 2]);      // Imaginary first
             float I = static_cast<float>(csi_data[sc_idx * 2 + 1]);  // Real second
             amplitude_buffer_[num_amplitudes_] = std::sqrt(I * I + Q * Q);
             num_amplitudes_++;
+
+            float phase = std::atan2(Q, I);
+            if (has_prev_phase && num_phase_diffs < HT20_SELECTED_BAND_SIZE) {
+                phase_diffs[num_phase_diffs++] = phase - prev_phase;
+            }
+            prev_phase = phase;
+            has_prev_phase = true;
         }
     }
     
+    // Phase turbulence: std of inter-subcarrier phase differences
+    last_phase_turbulence_ = (num_phase_diffs > 1)
+        ? std::sqrt(calculate_variance_two_pass(phase_diffs, num_phase_diffs))
+        : 0.0f;
+
+    // SA-WiSense ratio turbulence: std of adjacent amplitude ratios
+    if (num_amplitudes_ > 1) {
+        float ratios[HT20_SELECTED_BAND_SIZE];
+        uint8_t num_ratios = 0;
+        for (uint8_t i = 0; i + 1 < num_amplitudes_; i++) {
+            if (amplitude_buffer_[i + 1] > 0.1f) {
+                ratios[num_ratios++] = amplitude_buffer_[i] / amplitude_buffer_[i + 1];
+            }
+        }
+        last_ratio_turbulence_ = (num_ratios > 1)
+            ? std::sqrt(calculate_variance_two_pass(ratios, num_ratios))
+            : 0.0f;
+    } else {
+        last_ratio_turbulence_ = 0.0f;
+    }
+
     // Calculate spatial turbulence
     // Two modes:
     //   CV normalization (std/mean): gain-invariant, used when gain is NOT locked

--- a/components/espectre/base_detector.h
+++ b/components/espectre/base_detector.h
@@ -232,6 +232,9 @@ public:
      */
     bool is_hampel_enabled() const { return hampel_state_.enabled; }
 
+    float get_last_phase_turbulence() const { return last_phase_turbulence_; }
+    float get_last_ratio_turbulence() const { return last_ratio_turbulence_; }
+
 protected:
     /**
      * Add turbulence value to buffer (with filtering)
@@ -242,6 +245,8 @@ protected:
     float* turbulence_buffer_;
     float amplitude_buffer_[HT20_SELECTED_BAND_SIZE];  // Last packet amplitudes
     uint8_t num_amplitudes_;
+    float last_phase_turbulence_{0.0f};
+    float last_ratio_turbulence_{0.0f};
     uint16_t buffer_index_;
     uint16_t buffer_count_;
     uint16_t window_size_;


### PR DESCRIPTION
## Summary

Adds two new per-packet motion signals computed from CSI data, complementing the existing amplitude-based spatial turbulence:

- **Phase turbulence:** Standard deviation of inter-subcarrier phase differences. Differencing adjacent subcarriers cancels common-mode phase rotation (hardware artifact), making the metric sensitive to slow motion (breathing, fine movement) that amplitude variance misses.
- **SA-WiSense ratio turbulence:** Standard deviation of adjacent subcarrier amplitude ratios. Ratios cancel common-mode gain variations (AGC, interference) because neighboring subcarriers share the same hardware gain path. Based on the SA-WiSense noise cancellation technique.

Both signals are computed inline in `process_packet()` with no additional heap allocation (stack arrays of HT20_SELECTED_BAND_SIZE). They provide multi-domain motion information that can improve ML feature sets or be used as standalone supplementary indicators.

### Changes
- `base_detector.h` — `get_last_phase_turbulence()` and `get_last_ratio_turbulence()` public accessors
- `base_detector.cpp` — Phase diff accumulation and ratio computation in `process_packet()`, propagated in move semantics

## Test plan
- [x] Verify `get_last_phase_turbulence()` > 0 during motion, near 0 in empty room
- [x] Verify `get_last_ratio_turbulence()` responds to motion independently of amplitude variance
- [x] Compile for ESP32-S3 and ESP32

🤖 Generated with [Claude Code](https://claude.com/claude-code)